### PR TITLE
Update piggybank contract

### DIFF
--- a/cpp/Piggybank/PiggyOwner.cpp
+++ b/cpp/Piggybank/PiggyOwner.cpp
@@ -1,0 +1,52 @@
+#include <tvm/contract.hpp>
+#include <tvm/contract_handle.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/replay_attack_protection/timestamp.hpp>
+#include "PiggyOwner.hpp"
+#include "Piggybank.hpp"
+#include <tvm/msg_address.inline.hpp>
+
+using namespace tvm::schema;
+using namespace tvm;
+
+/// The contract which owns a piggybank. It can both deposit money to and
+/// them from the bank.
+class PiggyOwner final : public smart_interface<IPiggyOwner>,
+                         public DPiggyOwner {
+public:
+
+  /// Deploy the contract, do nothing aside from that.
+  __always_inline void constructor() final;
+  /// Asynchroniously call deposit method of Piggybank contract deployed
+  /// at \p bank, send \p balance nanograms to it.
+  __always_inline void deposit(lazy<MsgAddressInt> bank,
+                               uint_t<256> balance) final;
+  /// Asynchroniously call withdraw method of Piggybank contract deployed
+  /// at \p bank.
+  __always_inline void withdraw(lazy<MsgAddressInt> bank) final;
+
+  // Function is called in case of unparsed or unsupported func_id
+  static __always_inline int _fallback(cell msg, slice msg_body);
+};
+DEFINE_JSON_ABI(IPiggyOwner, DPiggyOwner, EPiggyOwner);
+
+// -------------------------- Public calls --------------------------------- //
+void PiggyOwner::constructor() {
+}
+
+void PiggyOwner::deposit(lazy<MsgAddressInt> bank, uint_t<256> balance) {
+  contract_handle<IPiggybank>(bank)(balance.get()).call<&IPiggybank::deposit>();
+}
+
+void PiggyOwner::withdraw(lazy<MsgAddressInt> bank) {
+  contract_handle<IPiggybank>(bank)().call<&IPiggybank::withdraw>();
+}
+
+// Fallback function
+int PiggyOwner::_fallback(cell msg, slice msg_body) {
+  tvm_accept();
+  return 0;
+}
+
+// ----------------------------- Main entry functions ---------------------- //
+DEFAULT_MAIN_ENTRY_FUNCTIONS(PiggyOwner, IPiggyOwner, DPiggyOwner, 1800)

--- a/cpp/Piggybank/PiggyOwner.hpp
+++ b/cpp/Piggybank/PiggyOwner.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <tvm/schema/message.hpp>
+
+namespace tvm { namespace schema {
+
+// Piggybank owner's interface
+struct IPiggyOwner {
+  __attribute__((internal, external))
+  void constructor() = 1;
+
+  __attribute__((external))
+  void deposit(lazy<MsgAddressInt> bank, uint_t<256> value) = 2;
+
+  __attribute__((external))
+  void withdraw(lazy<MsgAddressInt> bank) = 3;
+};
+
+// Piggybank owner's persistent data
+struct DPiggyOwner {
+  // At the moment a contract implemented using smart interface has to have
+  // at least one field in persistent data.
+  uint_t<1> x;
+};
+
+// Piggybank owner's events
+struct EPiggyOwner {};
+
+}} // namespace tvm::schema

--- a/cpp/Piggybank/PiggyStranger.cpp
+++ b/cpp/Piggybank/PiggyStranger.cpp
@@ -1,0 +1,44 @@
+#include <tvm/contract.hpp>
+#include <tvm/contract_handle.hpp>
+#include <tvm/smart_switcher.hpp>
+#include <tvm/replay_attack_protection/timestamp.hpp>
+#include "PiggyStranger.hpp"
+#include "Piggybank.hpp"
+#include <tvm/msg_address.inline.hpp>
+
+using namespace tvm::schema;
+using namespace tvm;
+
+class PiggyStranger final : public smart_interface<IPiggyStranger>,
+                            public DPiggyStranger {
+public:
+
+  /// Deploy the contract. Do nothing aside from that.
+  __always_inline void constructor() final;
+  /// Call deposit method of Piggybank contract deployed at \p bank and send
+  /// \p balance nanograms.
+  __always_inline void deposit(lazy<MsgAddressInt> bank,
+                               uint_t<256> balance) final;
+
+  // Function is called in case of unparsed or unsupported func_id
+  static __always_inline int _fallback(cell msg, slice msg_body);
+};
+DEFINE_JSON_ABI(IPiggyStranger, DPiggyStranger, EPiggyStranger);
+
+// -------------------------- Public calls --------------------------------- //
+void PiggyStranger::constructor() {
+}
+
+void PiggyStranger::deposit(lazy<MsgAddressInt> bank, uint_t<256> balance) {
+  contract_handle<IPiggybank>(bank)(balance.get()).call<&IPiggybank::deposit>();
+}
+
+// Fallback function
+int PiggyStranger::_fallback(cell msg, slice msg_body) {
+  tvm_accept();
+  return 0;
+}
+
+// ----------------------------- Main entry functions ---------------------- //
+DEFAULT_MAIN_ENTRY_FUNCTIONS(PiggyStranger, IPiggyStranger,
+                             DPiggyStranger, 1800)

--- a/cpp/Piggybank/PiggyStranger.hpp
+++ b/cpp/Piggybank/PiggyStranger.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <tvm/schema/message.hpp>
+
+namespace tvm { namespace schema {
+
+// Piggybank stranger's interface
+struct IPiggyStranger {
+  __attribute__((internal, external))
+  void constructor() = 1;
+
+  __attribute__((external))
+  void deposit(lazy<MsgAddressInt> bank, uint_t<256> value) = 2;
+};
+
+// Piggybank stranger's persistent data
+struct DPiggyStranger {
+  // At the moment a contract implemented using smart interface has to have
+  // at least one field in persistent data.
+  uint_t<1> x;
+};
+
+// Piggybank stranger's events
+struct EPiggyStranger {};
+
+}} // namespace tvm::schema

--- a/cpp/Piggybank/Piggybank.cpp
+++ b/cpp/Piggybank/Piggybank.cpp
@@ -1,6 +1,3 @@
-// RUN: %clang -O3 -S -c -emit-llvm -target tvm %s --sysroot=%S/../../../../../../stdlib -o -
-// REQUIRES: tvm-registered-target
-
 #include <tvm/contract.hpp>
 #include <tvm/smart_switcher.hpp>
 #include <tvm/replay_attack_protection/timestamp.hpp>
@@ -10,6 +7,9 @@
 using namespace tvm::schema;
 using namespace tvm;
 
+/// A contract which receives money from other contracts, and once the limit is
+/// reached a dedicated contract called the piggy bank owner is able to withdraw
+/// the savings.
 class Piggybank final : public smart_interface<IPiggybank>, public DPiggybank {
 public:
   struct error_code : tvm::error_code {
@@ -17,11 +17,23 @@ public:
     static constexpr int not_enough_balance = 102;
   };
 
-  __always_inline void constructor(lazy<MsgAddress> pb_owner, uint_t<256> pb_limit) final;
+  /// Deploy the contract and store \p pb_owner and \p pb_limit in
+  /// persistent memory.
+  __always_inline void constructor(lazy<MsgAddress> pb_owner,
+                                   uint_t<256> pb_limit) final;
+  /// When other contract calls deposit, the money it attached to the message
+  /// count towards the limit.
   __always_inline void deposit() final;
+  /// If called by the owner and savings exceeded the limit, send them
+  /// to the caller.
   __always_inline void withdraw() final;
+  /// Auxiliary method to get current amount of savings.
+  __always_inline uint_t<256> get_balance() final;
+
+  // Function is called in case of unparsed or unsupported func_id
+  static __always_inline int _fallback(cell msg, slice msg_body);
 };
-DEFINE_JSON_ABI(IPiggybank);
+DEFINE_JSON_ABI(IPiggybank, DPiggybank, EPiggybank);
 
 // -------------------------- Public calls --------------------------------- //
 void Piggybank::constructor(lazy<MsgAddress> pb_owner, uint_t<256> pb_limit) {
@@ -40,10 +52,19 @@ void Piggybank::withdraw() {
   require(sender.raw_slice() == owner.raw_slice(), error_code::wrong_owner);
   require(balance >= limit, error_code::not_enough_balance);
 
-  tvm_transfer(sender, balance, false);
+  tvm_transfer(sender, balance.get(), false);
   balance = 0;
 }
 
-// ----------------------------- Main entry functions ---------------------- //
-DEFAULT_MAIN_ENTRY_FUNCTIONS(Piggybank, IPiggybank, DPiggybank, 100)
+uint_t<256> Piggybank::get_balance() {
+  return balance;
+}
 
+// Fallback function
+int Piggybank::_fallback(cell msg, slice msg_body) {
+  tvm_accept();
+  return 0;
+}
+
+// ----------------------------- Main entry functions ---------------------- //
+DEFAULT_MAIN_ENTRY_FUNCTIONS(Piggybank, IPiggybank, DPiggybank, 1800)

--- a/cpp/Piggybank/Piggybank.hpp
+++ b/cpp/Piggybank/Piggybank.hpp
@@ -5,7 +5,7 @@
 namespace tvm { namespace schema {
 
 // Piggybank interface
-__interface IPiggybank {
+struct IPiggybank {
   __attribute__((internal, external))
   void constructor(lazy<MsgAddress> owner, uint_t<256> limit) = 1;
 
@@ -14,6 +14,9 @@ __interface IPiggybank {
 
   __attribute__((internal))
   void withdraw() = 3;
+
+  __attribute__((getter))
+  uint_t<256> get_balance() = 4;
 };
 
 // Piggybank persistent data
@@ -23,5 +26,7 @@ struct DPiggybank {
   uint_t<256> balance;
 };
 
-}} // namespace tvm::schema
+// Piggybank events
+struct EPiggybank {};
 
+}} // namespace tvm::schema

--- a/cpp/Piggybank/README.md
+++ b/cpp/Piggybank/README.md
@@ -1,64 +1,16 @@
 # Piggybank
 
+This example demonstrate message exchange between contracts.
+* `Piggybank` is the contract which accumulate savings.
+* `PiggyStranger` is the contract that can only deposit grams to `Piggybank`.
+* `PiggyOwner` is the contract that can deposit grams to `Piggybank` and withdraw all the saving when the saving goal is reached.
+
 ## Methods
-This contract has three methods.
-* `Piggybank::constructor(MsgAddress owner, uint256_t limit)` - initialization of contract.
-* `Piggybank::deposit()` - receive transfer and increase internal balance.
-* `Piggybank::withdraw()` - check that sender is owner, balance is greater than limit and transfer all balance to owner.
-
-## Persistent data
-* MsgAddress `owner` - contract's owner, initialized in `Piggybank::constructor()` call.
-* uint256_t `limit` - limit to allow withdrawal.
-* uint256_t `balance` - current balance.
-
-## Compilation (manual, step-by-step, without tvm-build++)
-
-Generate json-abi file:
-```
-clang -target tvm --sysroot TON-Compiler/stdlib/ Piggybank.cpp -export-json-abi -o Piggybank.abi
-```
-Compile into llvm ir file:
-```
-clang -target tvm -O3 --sysroot TON-Compiler/stdlib/ -c -S -emit-llvm Piggybank.cpp -o Piggybank.ll
-```
-Optimize llvm ir file #1:
-```
-opt Piggybank.ll -S -o Piggybank.opt1.ll -internalize -internalize-public-api-list=main_external,main_internal,main_ticktock,main_split,main_merge
-```
-Optimize llvm ir file #2:
-```
-opt -S -O3 Piggybank.opt1.ll -o Piggybank.opt2.ll
-```
-Assembly generation:
-```
-llc Piggybank.opt2.ll -O3 -o Piggybank.s
-```
-Linking of contract:
-```
-tvm_linker compile Piggybank.s --lib TON-Compiler/stdlib/stdlib_cpp.tvm --abi-json Piggybank.abi --genkey/setkey...
-```
-Variant with genkey:
-```
-tvm_linker compile Piggybank.s --lib TON-Compiler/stdlib/stdlib_cpp.tvm --abi-json Piggybank.abi --genkey Piggybank.key
-```
-Read "Key Generation and Usage" document about genkey/setkey details.
-
-Linking will produce file like `7a1c13d5bdf356c03ab4473714819095505df070ff3d61eab1ad5151319abf23.tvc`
-```
-Saved contract to file 7a1c13d5bdf356c03ab4473714819095505df070ff3d61eab1ad5151319abf23.tvc
-```
-
-## Test simulation
-Constructor call trace:
-```
-tvm_linker test --trace --decode-c6 -a Piggybank.abi -m constructor --abi-params='{"owner":"0:e6804f18c4147e9545c23dc4f9663650bead7aae26961558ef8d67e170f834ab", "limit":"10000"}' --sign Piggybank.key 7a1c13d5bdf356c03ab4473714819095505df070ff3d61eab1ad5151319abf23 > constructor.log
-```
-Deposit call trace:
-```
-tvm_linker test --trace --decode-c6 -a Piggybank.abi -m deposit --abi-params='{}' --sign Piggybank.key --internal 100000 7a1c13d5bdf356c03ab4473714819095505df070ff3d61eab1ad5151319abf23 > deposit.log
-```
-Withdraw call trace:
-```
-tvm_linker test --trace --decode-c6 -a Piggybank.abi -m withdraw --abi-params='{}' --sign Piggybank.key --internal 10 7a1c13d5bdf356c03ab4473714819095505df070ff3d61eab1ad5151319abf23 > withdraw.log
-```
-
+The contract has the following methods:
+* `Piggybank::constructor(lazy<MsgAddressInt> owner, uint_t<256> limit)` - method run on the contract's deploy. It stores an address of the contract which is treated as PiggyOwner. It also stores goal for saving money (`limit`).
+* `Piggybank::deposit()`. The method is supposed to be called by any contract (in particular `PiggyOwner` or `PiggyStranger`) to contribute to savings. Unlike a simple incoming message with balance, deposit call count the incoming money towards the saving goal.
+* `Piggybank::withdraw()`. The method is supposed to be called by the owner contract, otherwise the exception is thrown. If saving reach the goal, send them to the caller.
+* `Piggybank::get_balance()` - show the current amount of savings.
+* `PiggyOwner::deposit(lazy<MsgAddressInt> bank, uint_t<256> balance)`. Call `deposit` method of the contract deployed at `bank` address (the contract is expected to be `Piggybank`) and send `balance` nanograms to it.
+* `Piggybank::withdraw(lazy<MsgAddressInt> bank)`. Call `withdraw` method of the contract deployed at `bank` address (the contract is expected to be `Piggybank`).
+* `PiggyStranger::deposit(lazy<MsgAddressInt> bank, uint_t<256> balance)`. Call `deposit` method of the contract deployed at `bank` address (the contract is expected to be `Piggybank`) and send `balance` nanograms to it.


### PR DESCRIPTION
Make piggybank cp=ompatible with the recent version of C++ compiler and
libraries.
Add piggybank stranger and piggybank owner contracts.

===Piggybank Stranger Contract===
0:f9b3b3c9222f755af7b3050595d18ed005fb021633d9b531359f50ee73dba2a5

===Piggybank Owner Contract===
0:91da2d720add8e9a1dd5768c7252812622deec63ea9e33b638add06751e61e4d

===Piggybank Contract===
0:05226e488cff4a2620038cfb11cf90af734122bdf598705df744b7c1cf82d7bf